### PR TITLE
Alpine based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,15 @@
-FROM debian:buster
+FROM alpine:3.12
 
-ARG MONERO_VERSION=0.17.1.3
-ARG MONERO_SHA256=cf3fb693339caed43a935c890d71ecab5b89c430e778dc5ef0c3173c94e5bf64
-ENV PATH=/opt/monero:${PATH}
+# https://git.alpinelinux.org/aports/tree/testing/monero/APKBUILD
+ARG MONERO_VERSION=0.17.1.3-r0
 
-WORKDIR /opt
-
-RUN apt update && \
-    apt -y upgrade && \
-    apt -y install curl bzip2 && \
-    apt clean && \
-    apt -y autoremove && \
-    useradd -ms /bin/bash monero && \
+RUN apk update && \
+    apk --no-cache upgrade && \
+    apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ monero=${MONERO_VERSION} && \
+    addgroup monero && \
+    adduser -D -h /home/monero -s /bin/sh -G monero monero && \
     mkdir -p /home/monero/.bitmonero && \
-    chown -R monero:monero /home/monero/.bitmonero && \
-    curl https://downloads.getmonero.org/cli/monero-linux-x64-v$MONERO_VERSION.tar.bz2 -O && \
-    echo "$MONERO_SHA256  monero-linux-x64-v$MONERO_VERSION.tar.bz2" | sha256sum -c - && \
-    tar -xvf monero-linux-x64-v$MONERO_VERSION.tar.bz2 && \
-    rm -f monero-linux-x64-v$MONERO_VERSION.tar.bz2 && \
-    ln -s /opt/monero-x86_64-linux-gnu-v${MONERO_VERSION} /opt/monero
+    chown -R monero:monero /home/monero/.bitmonero
 
 USER monero
 
@@ -28,4 +19,4 @@ VOLUME /home/monero/.bitmonero
 
 EXPOSE 18080 18081
 
-ENTRYPOINT ["/opt/monero/monerod"]
+ENTRYPOINT ["/usr/bin/monerod"]


### PR DESCRIPTION
Pros:
* Image size is significantly reduced
  * From 151.8MB to 50MB (compressed)
* Quay Security Scan detects no vulnerabilities
  * 1 high vulnerability, 75 total vulnerabilities on the Debian based tags

Cons:
* Not a very big fan of using the testing repo and `apk add` to install monero,
  but I guess it'll have to do until it gets put in `community` repo.
* Would prefer to just be able to download the tarball directly from `getmonero.org`,
  install the required packages, and **not** rely on repo.
* In an ideal world, I'd use a multi-stage dockerfile to compile monero from source
  and then copy it to the main image

![image](https://user-images.githubusercontent.com/4052340/99060782-398a5580-25a9-11eb-93eb-a37d36b364d8.png)
