### PR TITLE
Use symlink for bitmonero volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ docker run \
   --restart=always \
   --net=host \
   --name=monerod \
-  -v /path/to/bitmonero:/home/monero/.bitmonero \
+  -v /path/to/bitmonero:/opt/bitmonero \
   ghcr.io/rblaine95/monero ${EXTRA_MONEROD_ARGS}
 ```
 


### PR DESCRIPTION
* Symlink `/opt/bitmonero` to `/home/monero/.bitmonero`
* Makes volume mounting cleaner
* Use `uname -m` to get CPU Architecture for build (maybe multi-arch
  builds in the future?)